### PR TITLE
Use public cache in dev

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -4,6 +4,19 @@ import { defineConfig } from "vite";
 
 // https://vitejs.dev/config/
 export default defineConfig({
+    server: {
+        // In dev mode, by default, the proxy and cache of the production server will be used.
+        // Can be disabled by setting the environment variable LOCAL_PROXY to true
+        proxy:
+            process.env.LOCAL_PROXY === "true"
+                ? {}
+                : {
+                      "/sssvt": {
+                          target: "https://rozvrh.icy.cx",
+                          changeOrigin: true
+                      }
+                  }
+    },
     plugins: [
         sveltekit(),
         svg({


### PR DESCRIPTION
By default, when using the dev server, sssvt proxy connections will be going to the production server.

This is so the live cache can be used. You can ofc disable this by setting the environment variable `LOCAL_PROXY=true`.